### PR TITLE
Fixed "Frameworks" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Recognition](http://nlp.stanford.edu/~socherr/pa4_ner.pdf) [zip](http://nlp.stan
 15.  [OpenDL](https://github.com/guoding83128/OpenDL)
 16.  [cuDNN](https://developer.nvidia.com/cuDNN)
 17.  [MGL](http://melisgl.github.io/mgl-pax-world/mgl-manual.html)
-18. [KUnet.jl](https://github.com/denizyuret/KUnet.jl)
-19  [Nvidia DIGITS (a web app based on Caffe)](github.com/NVIDIA/DIGITS)
+18.  [KUnet.jl](https://github.com/denizyuret/KUnet.jl)
+19.  [Nvidia DIGITS - a web app based on Caffe](github.com/NVIDIA/DIGITS)
 
 
 ### Miscellaneous


### PR DESCRIPTION
Item 19 was replicated. This fixes it. The problem was the parentheses inside the link.