### PR TITLE
Fixed link to Nvidia DIGITS

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Recognition](http://nlp.stanford.edu/~socherr/pa4_ner.pdf) [zip](http://nlp.stan
 16.  [cuDNN](https://developer.nvidia.com/cuDNN)
 17.  [MGL](http://melisgl.github.io/mgl-pax-world/mgl-manual.html)
 18.  [KUnet.jl](https://github.com/denizyuret/KUnet.jl)
-19.  [Nvidia DIGITS - a web app based on Caffe](github.com/NVIDIA/DIGITS)
+19.  [Nvidia DIGITS - a web app based on Caffe](https://github.com/NVIDIA/DIGITS)
 20.  [Neon - Python based Deep Learning Framework](https://github.com/NervanaSystems/neon)
 21.  [Keras - Theano based Deep Learning Library](http://keras.io)
 


### PR DESCRIPTION
it was a relative url and not an absolute url. This fixes that.