### PR TITLE
Fixed Caffe Dockerfile url

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Recognition](http://nlp.stanford.edu/~socherr/pa4_ner.pdf) [zip](http://nlp.stan
 2.  [Caffe Webinar](http://on-demand-gtc.gputechconf.com/gtcnew/on-demand-gtc.php?searchByKeyword=shelhamer&amp;searchItems=&amp;sessionTopic=&amp;sessionEvent=4&amp;sessionYear=2014&amp;sessionFormat=&amp;submit=&amp;select=+)
 3.  [100 Best Github Resources in Github for DL](http://meta-guide.com/software-meta-guide/100-best-github-deep-learning/)
 4.  [Word2Vec](https://code.google.com/p/word2vec/)
-5.  [Caffe DockerFile](https://registry.hub.docker.com/u/tleyden5iwx/caffe/)
+5.  [Caffe DockerFile](https://github.com/tleyden/docker/tree/master/caffe)
 6.  [TorontoDeepLEarning convnet](https://github.com/TorontoDeepLearning/convnet)
 7.  [Vision data sets](http://www.cs.cmu.edu/~cil/v-images.html)
 8.  [gfx.js](https://github.com/clementfarabet/gfx.js)


### PR DESCRIPTION
it linked to a 404 page. now linked to a github page with GPU and CPU variants of the Dockerfile