### PR TITLE
Adding link to IPAM's summer school lectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 10.  [Neural Networks - usherbrooke](http://info.usherbrooke.ca/hlarochelle/neural_networks/content.html)
 11.  [Machine Learning - Oxford](https://www.cs.ox.ac.uk/people/nando.defreitas/machinelearning/) (2014-2015)
 12.  [Deep Learning - Nvidia](https://developer.nvidia.com/deep-learning-courses) (2015)
+13.  [Graduate Summer School: Deep Learning, Feature Learning] (https://www.youtube.com/playlist?list=PLHyI3Fbmv0SdzMHAy0aN59oYnLy5vyyTA) by Geoffrey Hinton, Yoshua Bengio, Yann LeCun, Andrew Ng, Nando de Freitas and several others @ IPAM, UCLA (2012)
 
 
 ### Videos and Lectures


### PR DESCRIPTION
Have added a link to IPAM, UCLA 2012 summer school on deep learning and feature learning. I wasn't sure whether to add to courses or lectures but decided to go with courses.