### PR TITLE
rename KUnet.jl as Knet.jl (it's been a while)

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Recognition](http://nlp.stanford.edu/~socherr/pa4_ner.pdf) [zip](http://nlp.stan
 15.  [OpenDL](https://github.com/guoding83128/OpenDL)
 16.  [cuDNN](https://developer.nvidia.com/cuDNN)
 17.  [MGL](http://melisgl.github.io/mgl-pax-world/mgl-manual.html)
-18.  [KUnet.jl](https://github.com/denizyuret/KUnet.jl)
+18.  [Knet.jl](https://github.com/denizyuret/Knet.jl)
 19.  [Nvidia DIGITS - a web app based on Caffe](https://github.com/NVIDIA/DIGITS)
 20.  [Neon - Python based Deep Learning Framework](https://github.com/NervanaSystems/neon)
 21.  [Keras - Theano based Deep Learning Library](http://keras.io)


### PR DESCRIPTION
KUnet.jl link was broken because the project name was changed as Knet.jl. This commit fixes it.