### PR TITLE
Add Classpert Deep Learning Online Course List

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 36. [Deep Reinforcement Learning (nanodegree) - Udacity](https://www.udacity.com/course/deep-reinforcement-learning-nanodegree--nd893) a 3-6 month Udacity nanodegree, spanning multiple courses (2018)
 37. [Grokking Deep Learning in Motion](https://www.manning.com/livevideo/grokking-deep-learning-in-motion) by Beau Carnes (2018)
 38. [Face Detection with Computer Vision and Deep Learning](https://www.udemy.com/share/1000gAA0QdcV9aQng=/) by Hakan Cebeci
+39. [Deep Learning Online Course list at Classpert](https://classpert.com/deep-learning) List of Deep Learning online courses (some are free) from Classpert Online Course Search
 
 ### Videos and Lectures
 


### PR DESCRIPTION
This commit adds Classpert to the section "Courses", containing links for Deep Learning Online Courses (some free) from top e-learning providers such as Udacity, Udemy and EDX.