### PR TITLE
Update README.md for Andrej Karpathy website

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@
 5. [ Alex Krizhevsky ](http://www.cs.utoronto.ca/~kriz/index.html)
 6. [ Alexander Ilin ](http://users.ics.aalto.fi/alexilin/)
 7. [ Amos Storkey ](http://homepages.inf.ed.ac.uk/amos/)
-8. [ Andrej Karpathy ](http://cs.stanford.edu/~karpathy/)
+8. [ Andrej Karpathy ](https://karpathy.ai/)
 9. [ Andrew M. Saxe ](http://www.stanford.edu/~asaxe/)
 10. [ Andrew Ng ](http://www.cs.stanford.edu/people/ang/)
 11. [ Andrew W. Senior ](http://research.google.com/pubs/author37792.html)


### PR DESCRIPTION
The current website (https://cs.stanford.edu/~karpathy/) of Andrej Karpathy has been deprecated for quite some time. And its been mentioned clearly in his current website (below screenshot). Hence in this PR, just updating the site URL to the new one (https://karpathy.ai/)

![image](https://user-images.githubusercontent.com/12703975/94971660-26558600-0525-11eb-926e-4532c4c648b8.png)
