### PR TITLE
remove unavailable website

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,7 @@
 34.  [AI Summer](https://theaisummer.com/)
 35.  [AI Hub - supported by AAAI, NeurIPS](https://aihub.org/)
 36.  [CatalyzeX: Machine Learning Hub for Builders and Makers](https://www.catalyzeX.com)
-37.  [The Epic Code](https://theepiccode.com/)
-38.  [all AI news](https://allainews.com/)
+37.  [all AI news](https://allainews.com/)
 
 ### Datasets
 


### PR DESCRIPTION
theepiccode website is down
the website status can be checked here https://www.isitdownrightnow.com/theepiccode.com.html