### PR TITLE
Added AI Conference Deadline to "Websites"

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@
 36.  [CatalyzeX: Machine Learning Hub for Builders and Makers](https://www.catalyzeX.com)
 37.  [The Epic Code](https://theepiccode.com/)
 38.  [all AI news](https://allainews.com/)
+39.  [AI Conference Deadline](https://www.aiconferenceddl.com/)
 
 ### Datasets
 


### PR DESCRIPTION
This PR adds [AI Conference Deadline](https://www.aiconferenceddl.com/) as a research resource under "Websites". It’s a simple tracker for AI and ML conference submission deadlines in one place.